### PR TITLE
Update reminders command to expose only reminders from current guild

### DIFF
--- a/commands/remind.js
+++ b/commands/remind.js
@@ -32,12 +32,8 @@ module.exports = {
 		}
 
 		const endTime = startTime + userInputTime;
-		let guild_id;
-		if (message.channel.type == "dm") {
-			guild_id = "dm";
-		} else {
-			guild_id = message.guild.id;
-		}
+		let guild_id = "dm";
+		if (message.channel.type !== "dm") guild_id = message.guild.id;
 
 		idToRemove = createReminder.run(message.author.id, message.channel.id, guild_id, userReminder, startTime, endTime).lastInsertRowid;
 

--- a/commands/reminders.js
+++ b/commands/reminders.js
@@ -13,12 +13,8 @@ module.exports = {
 		// select all from reminders
 		const reminders = db.prepare("SELECT * from reminders WHERE user_id = (?)").all(message.author.id);
 
-		let guild_id;
-		if (message.channel.type === "dm") {
-			guild_id = "dm";
-		} else {
-			guild_id = message.guild.id;
-		}
+		let guild_id = "dm";
+		if (message.channel.type !== "dm") guild_id = message.guild.id;
 
 		if (args[0] === "clear") {
 			if (args.length === 2) {

--- a/index.js
+++ b/index.js
@@ -43,9 +43,12 @@ client.once("ready", () => {
 		const channelToPost = await client.channels.fetch(reminder.channel_id);
 		const timeToRun = reminder.end_time - currentTime;
 		const removeReminder = db.prepare("DELETE FROM reminders WHERE id = (?)");
+		const reminderEmbed = new Discord.MessageEmbed()
+			.setColor("#36393f")
+			.setDescription(`⏰ ${reminder.message}`)
 
 		const onCompletion = () => {
-			channelToPost.send(`💖 **${userToRemind.toString()}, here's your reminder: ${reminder.message}.**`, { disableMentions: "everyone" });
+			channelToPost.send(`💖 **${userToRemind.toString()}**, here's your reminder:`, { embed: reminderEmbed });
 			removeReminder.run(reminder.id);
 		}
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ client.once("ready", () => {
 
 	if (!tableResult['count(*)']) {
 		db.prepare(
-			"CREATE TABLE IF NOT EXISTS reminders (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL, channel_id TEXT NOT NULL, message TEXT NOT NULL, start_time INTEGER NOT NULL, end_time INTEGER NOT NULL);"
+			"CREATE TABLE IF NOT EXISTS reminders (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, message TEXT NOT NULL, start_time INTEGER NOT NULL, end_time INTEGER NOT NULL);"
 		).run();
 		// prep db
 		db.pragma("journal_mode = WAL");
@@ -39,8 +39,8 @@ client.once("ready", () => {
 	const reminders = db.prepare("SELECT * from reminders").all();
 	const currentTime = Date.now();
 	reminders.forEach(async (reminder) => {
-		const userToRemind = await client.users.fetch(reminder.user_id, true);
-		const channelToPost = await client.channels.fetch(reminder.channel_id, true);
+		const userToRemind = await client.users.fetch(reminder.user_id);
+		const channelToPost = await client.channels.fetch(reminder.channel_id);
 		const timeToRun = reminder.end_time - currentTime;
 		const removeReminder = db.prepare("DELETE FROM reminders WHERE id = (?)");
 


### PR DESCRIPTION
Adds a new column to the reminders table, `guild_id`, so we can check against it to only expose any  reminders that are upcoming in the current server or DM.

Messages have been changed into embeds, as they look clearly distinct as a bot message.