### PR TITLE
Add per-guild settings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,6 @@
     "jest": true
   },
   "globals": {
-    "reminderObj": true,
     "log": true
   },
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
   },
   "ignorePatterns": ["node_modules/"],
   "rules": {
-    "indent": ["error", "tab"],
+    "indent": ["error", "tab", { "SwitchCase": 1 }],
     "no-console": "off",
 		"no-mixed-spaces-and-tabs": ["error", "smart-tabs"],
     "no-var": "error",

--- a/__tests__/say.test.js
+++ b/__tests__/say.test.js
@@ -1,4 +1,5 @@
 const say = require("../commands/say.js");
+const embed = require("../utils/embed.js");
 
 function logMessage(string, user) {
 	let minute = new Date().getMinutes().toString();
@@ -22,7 +23,8 @@ const fakeChannel = {
 			has: jest.fn(() => {
 				 return true;
 			})
-		};})
+		};
+	})
 };
 
 const fakeArgs = ["how", "do", "i", "make", "the", "bot", "work"];
@@ -64,9 +66,9 @@ describe("!say command executes correctly", () => {
 
 	test("If user input is not provided, the bot informs the user", () => {
 		say.execute(fakeMessage, []);
-		expect(fakeMessage.channel.send).toHaveBeenCalledWith(
-			"❣ **You need to tell me what to say!**"
-		);
+		expect(fakeMessage.channel.send).toHaveBeenCalledWith({
+			embed: embed("❣ **You need to tell me what to say!**")
+		});
 	});
 
 	test("If a channel is mentioned, the bot sends the message to that channel", async () => {
@@ -76,7 +78,9 @@ describe("!say command executes correctly", () => {
 		await say.execute(fakeMessageClone, fakeArgsClone);
 
 		expect(fakeMessage.mentions.channels.first().send).toHaveBeenCalledWith("how do i make the bot work");
-		expect(fakeMessage.channel.send).toHaveBeenCalledWith("💖 **Message sent.**");
+		expect(fakeMessage.channel.send).toHaveBeenCalledWith({
+			embed: embed("💖 **Message sent.**")
+		});
 	});
 
 	test("If the bot lacks permissions to send the message, the bot informs the user", async () => {
@@ -93,8 +97,8 @@ describe("!say command executes correctly", () => {
 		fakeMessageClone.mentions.channels.first = jest.fn(() => fakeChannelBanned);
 
 		await say.execute(fakeMessageClone, fakeArgsClone);
-		expect(fakeMessageClone.channel.send).toHaveBeenCalledWith(
-			"💔 **I can't send a message in that channel.**"
-		);
+		expect(fakeMessageClone.channel.send).toHaveBeenCalledWith({
+			embed: embed("💔 **I can't send a message in that channel.**")
+		});
 	});
 });

--- a/commands/ban.js
+++ b/commands/ban.js
@@ -1,3 +1,5 @@
+const embed = require("../utils/embed.js");
+
 module.exports = {
 	name: "ban",
 	description: "Bans a very naughty user.",
@@ -6,29 +8,42 @@ module.exports = {
 	guildOnly: true,
 	modOnly: true,
 	execute(message) {
-		const taggedUser = message.mentions.users.first();
+		const user = message.mentions.members.first();
 
 		if (!message.mentions.users.size) {
-			return message.channel.send(
-				"❣ **You need to mention a user in order to ban them!**"
-			);
+			return message.channel.send({
+				embed: embed("❣ **You need to mention a user in order to ban them!**")
+			});
 		}
 
-		if (!message.guild.member(taggedUser).banable) {
-			return message.channel.send("💔 **I can't ban this user.**");
-		}
+		if (user) {
+			const member = message.guild.member(user);
+			if (!member) {
+				return message.channel.send({
+					embed: embed("❣ **I can't find that user. Are they in this server?**")
+				});
+			}
 
-		message.guild.members
-			.ban(taggedUser, {
+			if (!member.manageable) {
+				return message.channel.send({
+					embed: embed("❣ **I don't have the correct permissions to do that.**")
+				});
+			}
+
+			member.ban({
 				reason: `Banned by ${message.author.username} via command.`
 			})
-			.catch(err => {
-				log.error(err);
-				message.channel.send(
-					"💔 **There was an error trying to ban that user!**"
-				);
-			});
-
-		message.channel.send("💖 **Banned.** 🔨");
+				.then(() => {
+					message.channel.send({
+						embed: embed(`💖 **${user.tag} was banned.** 🔨`)
+					});
+				})
+				.catch(err => {
+					log.error(err);
+					message.channel.send({
+						embed: embed("💔 **There was an error trying to ban that user!**")
+					});
+				});
+		}
 	}
 };

--- a/commands/eval.js
+++ b/commands/eval.js
@@ -1,3 +1,5 @@
+const embed = require("../utils/embed.js");
+
 module.exports = {
 	name: "eval",
 	description: "Evaluates arbitrary JavaScript.",
@@ -5,6 +7,10 @@ module.exports = {
 	guildOnly: true,
 	modOnly: true,
 	execute(message, args) {
+		// return silently if not Sierra#0001
+		// due to the nature of eval
+		if (message.author.id !== "190917462265430016") return;
+
 		const data = [];
 		const clean = text => {
 			if (typeof text === "string") {
@@ -15,10 +21,6 @@ module.exports = {
 				return text;
 			}
 		};
-
-		if (message.author.id !== "190917462265430016") {
-			data.push("❣ **You can't use that command.**");
-		}
 
 		try {
 			const code = args.join(" ");
@@ -33,7 +35,9 @@ module.exports = {
 				split: true
 			});
 		} catch (err) {
-			message.channel.send(`💔 **ERROR** \`\`\`xl\n${clean(err)}\n\`\`\``);
+			message.channel.send({
+				embed: embed(`💔 **ERROR** \`\`\`xl\n${clean(err)}\n\`\`\``)
+			});
 		}
 	}
 };

--- a/commands/flip.js
+++ b/commands/flip.js
@@ -1,3 +1,5 @@
+const embed = require("../utils/embed.js");
+
 module.exports = {
 	name: "flip",
 	description: "Flips a coin!",
@@ -8,10 +10,14 @@ module.exports = {
 		  return (Math.random() >= 0.5) ? 'Heads' : 'Tails';
 		};
 
-		message.channel.send(`💞 **Flipping a coin...**`)
+		message.channel.send({
+			embed: embed(`💞 **Flipping a coin...**`)
+		})
 		  .then(msg => {
 		    setTimeout(() => {
-		      msg.edit(`💖 **${flip()}!**`);
+		      msg.edit({
+						embed: embed(`💖 **${flip()}!**`)
+					});
 		    }, 2000);
 			});
 	}

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,4 +1,4 @@
-const { prefix } = require("../config.json");
+const settings = require("../utils/settings.js");
 
 module.exports = {
 	name: "help",
@@ -7,6 +7,7 @@ module.exports = {
 	usage: "[command name]",
 	cooldown: 5,
 	execute(message, args) {
+		const guildSettings = settings.getSettings(message.guild.id);
 		const data = [];
 		const { commands } = message.client;
 		const commandList = commands
@@ -17,7 +18,7 @@ module.exports = {
 			data.push("💖 **Here's a list of all my commands:**");
 			data.push(commandList);
 			data.push(
-				`\nYou can send \`${prefix}help [command name]\` to get info on a specific command!`
+				`\nYou can send \`!help [command name]\` to get info on a specific command!`
 			);
 
 			return message.author
@@ -62,7 +63,7 @@ module.exports = {
 		}
 		
 		if (command.usage) {
-			data.push(`**Usage:** \`${prefix}${command.name}\` \`${command.usage}\``);
+			data.push(`**Usage:** \`${guildSettings.prefix}${command.name}\` \`${command.usage}\``);
 		}
 
 		data.push(`**Cooldown:** \`${command.cooldown || 3}\` second(s).`);

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,3 +1,4 @@
+const embed = require("../utils/embed.js");
 const settings = require("../utils/settings.js");
 
 module.exports = {
@@ -7,36 +8,35 @@ module.exports = {
 	usage: "[command name]",
 	cooldown: 5,
 	execute(message, args) {
-		const guildSettings = settings.getSettings(message.guild.id);
-		const data = [];
+		let guildSettings = {};
+		if (message.channel.type !== "dm") guildSettings = settings.getSettings(message.guild.id);
 		const { commands } = message.client;
-		const commandList = commands
-			.filter(command => !command.modOnly)
-			.map(command => `\`${command.name}\``).join(", ");
 
 		if (!args.length) {
-			data.push("💖 **Here's a list of all my commands:**");
-			data.push(commandList);
-			data.push(
-				`\nYou can send \`!help [command name]\` to get info on a specific command!`
-			);
+			const helpEmbed = embed(`You can send \`!help [command name]\` to get info on a specific command!`);
+			helpEmbed.setTitle("💖 **Here's a list of all my commands:**");
+			
+			commands
+				.filter(command => !command.modOnly)
+				.forEach(command => helpEmbed.addField(`**${command.name}**`, command.description || "\u200b"));
 
 			return message.author
-				.send(data, { split: true })
-				.then(() => {
+				.send({
+					embed: helpEmbed
+				}).then(() => {
 					if (message.channel.type === "dm") return;
-					message.channel.send(
-						"💖 **I've sent you a message with all my commands!~**"
-					);
+					message.channel.send({
+						embed: embed("💖 **I've sent you a message with all my commands!~**")
+					});
 				})
 				.catch(error => {
 					log.error(
 						`Could not send help DM to ${message.author.tag}.\n`,
 						error
 					);
-					message.channel.send(
-						"💔 **I wish I could tell you, but I can't message you. Change that, or ask for help!**"
-					);
+					message.channel.send({
+						embed: embed("💔 **I wish I could tell you, but I can't message you. Change that, or ask for help!**")
+					});
 				});
 		}
 
@@ -46,29 +46,30 @@ module.exports = {
       commands.find(c => c.aliases && c.aliases.includes(name));
 
 		if (!command) {
-			return message.channel.send(
-				"❣ **I'm sorry, I don't know that one.**"
-			);
+			return message.channel.send({
+				embed: embed("❣ **I'm sorry, I don't know that one.**")
+			});
 		}
 
-		data.push(`💖 **Cutiebot Help~**\n`);
-		data.push(`**Command:** \`${command.name}\``);
+		const commandEmbed = embed(`**Command:** \`${command.name}\``);
+		commandEmbed.setTitle(`💖 **Cutiebot Help~**`);
 
 		if (command.aliases) {
-			data.push(`**Aliases:** \`${command.aliases.join("`, `")}\``);
+			commandEmbed.addField("**Aliases:**", `\`${command.aliases.join("`, `")}\``);
 		}
 
 		if (command.description) {
-			data.push(`**Description:** ${command.description}`);
+			commandEmbed.addField("**Description:**", `${command.description}`);
 		}
 		
 		if (command.usage) {
-			data.push(`**Usage:** \`${guildSettings.prefix}${command.name}\` \`${command.usage}\``);
+			commandEmbed.addField("**Usage:**", `\`${guildSettings.prefix || "!"}${command.name}\` \`${command.usage}\``);
 		}
 
-		data.push(`**Cooldown:** \`${command.cooldown || 3}\` second(s).`);
-		message.channel.send(data, {
-			split: true
+		commandEmbed.addField("**Cooldown:**", `\`${command.cooldown || 3}\` second${command.cooldown != 1 ? "s" : ""}.`);
+
+		message.channel.send({
+			embed: commandEmbed
 		});
 	}
 };

--- a/commands/kick.js
+++ b/commands/kick.js
@@ -1,3 +1,5 @@
+const embed = require("../utils/embed.js");
+
 module.exports = {
 	name: "kick",
 	description: "Kicks a naughty user.",
@@ -7,26 +9,40 @@ module.exports = {
 	guildOnly: true,
 	modOnly: true,
 	execute(message) {
-		const taggedUser = message.mentions.users.first();
+		const user = message.mentions.users.first();
 
 		if (!message.mentions.users.size) {
-			return message.channel.send(
-				"❣ **You need to mention a user in order to kick them!**"
-			);
-		}
-
-		if (!message.guild.member(taggedUser).kickable) {
-			return message.channel.send("💔 **I can't kick this user.**");
-		}
-
-		taggedUser.kick(`Kicked by ${message.author.username} via command.`)
-			.catch(err => {
-				log.error(err);
-				message.channel.send(
-					"💔 **There was an error trying to kick that user!**"
-				);
+			return message.channel.send({
+				embed: embed("❣ **You need to mention a user in order to kick them!**")
 			});
+		}
 
-		message.channel.send("💖 **Kicked.** 👟");
+		if (user) {
+			const member = message.guild.member(user);
+			if (!member) {
+				return message.channel.send({
+					embed: embed("❣ **I can't find that user. Are they in this server?**")
+				});
+			}
+
+			if (!member.manageable) {
+				return message.channel.send({
+					embed: embed("❣ **I don't have the correct permissions to do that.**")
+				});
+			}
+
+			member.kick(`Kicked by ${message.author.username} via command.`)
+				.then(() => {
+					message.channel.send({
+						embed: embed(`💖 **${user.tag} was kicked.** 👟`)
+					});
+				})
+				.catch(err => {
+					log.error(err);
+					message.channel.send({
+						embed: embed("💔 **There was an error trying to kick that user!**")
+					});
+				});
+		}
 	}
 };

--- a/commands/prune.js
+++ b/commands/prune.js
@@ -1,3 +1,5 @@
+const embed = require("../utils/embed.js");
+
 module.exports = {
 	name: 'prune',
 	description: 'Prune up to 99 messages.',
@@ -10,15 +12,27 @@ module.exports = {
 		const amount = parseInt(args[0]) + 1;
 
 		if (isNaN(amount)) {
-			return message.channel.send('❣ **You need to specify a number of messages for me to delete!**');
+			return message.channel.send({
+				embed: embed('❣ **You need to specify a number of messages for me to delete!**')
+			});
 		} else if (amount <= 1 || amount > 100) {
-			return message.channel.send('❣ **You need to input a number between 1 and 99.**');
+			return message.channel.send({
+				embed: embed('❣ **You need to input a number between 1 and 99.**')
+			});
+		}
+
+		if (!message.channel.permissionsFor(message.guild.me).has("MANAGE_MESSAGES", false)) {
+			return message.channel.send({
+				embed: embed("❣️ **I don't have permission to manage messages in this channel.**")
+			});
 		}
 
 		message.channel.bulkDelete(amount, true)
 			.then(messages => {
-				log.info(`${message.author.username} deleted ${messages.size} messages in #${message.channel.name}, on ${message.guild.name}.`);
-				message.channel.send(`💖 **Deleted ${messages.size} message(s).** 🔥`).then(msg => {
+				log.info(`${message.author.username} deleted ${messages.size - 1} messages in #${message.channel.name}, on ${message.guild.name}.`);
+				message.channel.send({
+					embed: embed(`💖 **Deleted ${messages.size - 1} message(s).** 🔥`)
+				}).then(msg => {
 					msg.delete({
 						timeout: 5000,
 						reason: "Prune command invoked."
@@ -27,7 +41,9 @@ module.exports = {
 			})
 			.catch(err => {
 				log.error(err);
-				message.channel.send('💔 **There was an error trying to prune messages in this channel!**');
+				message.channel.send({
+					embed: embed('💔 **There was an error trying to prune messages in this channel!**')
+				});
 			});
 	},
 };

--- a/commands/reboot.js
+++ b/commands/reboot.js
@@ -1,14 +1,20 @@
+const embed = require("../utils/embed.js");
+
 module.exports = {
 	name: "reboot",
 	description: "Restarts Cutiebot.",
 	cooldown: 0,
-	guildOnly: true,
+	guildOnly: false,
 	modOnly: true,
 	execute(message) {
-		message.channel.send("💞 **Shutting down.** 📴")
-			.then(() => {
-				log.warn(`Rebooted via command at ${new Date().toUTCString()}`);
-				process.exit();
-			});
+		// return silently if not Sierra#0001
+		if (message.author.id !== "190917462265430016") return;
+		
+		message.channel.send({
+			embed: embed("💞 **Shutting down.** 📴")
+		}).then(() => {
+			log.warn(`Rebooted via command at ${new Date().toUTCString()}`);
+			process.exit();
+		});
 	}
 };

--- a/commands/remind.js
+++ b/commands/remind.js
@@ -1,6 +1,6 @@
-const db = require("better-sqlite3")("./database/cutiebot.db");
 const Discord = require("discord.js");
 const ms = require('ms');
+const reminders = require("../utils/reminders.js");
 
 module.exports = {
 	name: "remind",
@@ -10,47 +10,27 @@ module.exports = {
 	cooldown: 5,
 	guildOnly: false,
 	execute(message, args) {
-		const startTime = Date.now();
-		let idToRemove;
-		const createReminder = db.prepare("INSERT INTO reminders (user_id, channel_id, guild_id, message, start_time, end_time) VALUES (?, ?, ?, ?, ?, ?)");
-		const removeReminder = db.prepare("DELETE FROM reminders WHERE id = (?)");
+		let duration = ms(`${args[0]} ${args[1]}`);
+		let content = args.slice(2).join(" ");
 
-		let userInputTime = ms(`${args[0]} ${args[1]}`);
-		let userReminder = args.slice(2).join(" ");
-
-		if (!userInputTime) {
-			userInputTime = ms(args[0]);
-			userReminder = args.slice(1).join(" ");
+		if (!duration) {
+			duration = ms(args[0]);
+			content = args.slice(1).join(" ");
 		}
 
-		if (!userReminder) {
+		if (!content) {
 			return message.channel.send("❣ **You need to tell me what to remind you about!**");
 		}
 
-		if (!userInputTime) {
+		if (!duration) {
 			return message.channel.send("❣ **You need to specify a time for me to remind you about that.**");
 		}
-
-		const endTime = startTime + userInputTime;
-		let guild_id = "dm";
-		if (message.channel.type !== "dm") guild_id = message.guild.id;
-
-		idToRemove = createReminder.run(message.author.id, message.channel.id, guild_id, userReminder, startTime, endTime).lastInsertRowid;
-
-		const reminderEmbed = new Discord.MessageEmbed()
-			.setColor("#36393f")
-			.setDescription(`⏰ ${userReminder}`);
-
-		let timeoutID = setTimeout(() => {
-			message.channel.send(`💖 **${message.author.toString()}**, here's your reminder:`, { embed: reminderEmbed });
-			removeReminder.run(idToRemove);
-		}, userInputTime);
-
-		reminderObj[idToRemove] = timeoutID;
+		
+		reminders.registerReminder(message.author, message.channel, message.guild, content, duration);
 
 		const reminderSet = new Discord.MessageEmbed()
 			.setColor("#36393f")
-			.setDescription(`💞 **${message.author.username}**, I'll remind you in ${ms(userInputTime, { long:true })}: **${userReminder}**. ⏰`);
+			.setDescription(`💞 **${message.author.username}**, I'll remind you in ${ms(duration, { long: true })}: **${content}**. ⏰`);
 
 		// tell user their reminder was set
 		message.channel.send({ embed: reminderSet });

--- a/commands/remind.js
+++ b/commands/remind.js
@@ -1,10 +1,10 @@
-const Discord = require("discord.js");
 const ms = require('ms');
 const reminders = require("../utils/reminders.js");
+const embed = require("../utils/embed.js");
 
 module.exports = {
 	name: "remind",
-	description: "",
+	description: "Create reminders",
 	aliases: ["reminder", "remindme"],
 	usage: '<time> <reminder>',
 	cooldown: 5,
@@ -19,20 +19,22 @@ module.exports = {
 		}
 
 		if (!content) {
-			return message.channel.send("❣ **You need to tell me what to remind you about!**");
+			return message.channel.send({
+				embed: embed("❣ **You need to tell me what to remind you about!**")
+			});
 		}
 
 		if (!duration) {
-			return message.channel.send("❣ **You need to specify a time for me to remind you about that.**");
+			return message.channel.send({
+				embed: embed("❣ **You need to specify a time for me to remind you about that.**")
+			});
 		}
 		
 		reminders.registerReminder(message.author, message.channel, message.guild, content, duration);
 
-		const reminderSet = new Discord.MessageEmbed()
-			.setColor("#36393f")
-			.setDescription(`💞 **${message.author.username}**, I'll remind you in ${ms(duration, { long: true })}: **${content}**. ⏰`);
-
 		// tell user their reminder was set
-		message.channel.send({ embed: reminderSet });
+		message.channel.send({
+			embed: embed(`💞 **${message.author.username}**, I'll remind you in ${ms(duration, { long: true })}: **${content}**. ⏰`)
+		});
 	}
 };

--- a/commands/reminders.js
+++ b/commands/reminders.js
@@ -38,14 +38,10 @@ module.exports = {
 			return message.channel.send({ embed: embed });
 		}
 
-		console.log(userReminders);
-
 		let validReminders = userReminders.filter(reminder => {
 			if (reminder.guild_id === guildID) return true;
 			return false;
 		});
-
-		console.log(validReminders);
 
 		if (validReminders.length) {
 			embed.setDescription(`💞 **${message.author.username}**, here are your upcoming reminders: ⏰`);

--- a/commands/reminders.js
+++ b/commands/reminders.js
@@ -1,6 +1,6 @@
-const db = require("better-sqlite3")("./database/cutiebot.db");
 const Discord = require("discord.js");
 const ms = require('ms');
+const reminders = require("../utils/reminders.js");
 
 module.exports = {
 	name: "reminders",
@@ -10,47 +10,48 @@ module.exports = {
 	cooldown: 5,
 	guildOnly: false,
 	execute(message, args) {
+		const embed = new Discord.MessageEmbed()
+			.setColor("#36393f");
 		// select all from reminders
-		const reminders = db.prepare("SELECT * from reminders WHERE user_id = (?)").all(message.author.id);
+		// const reminders = db.prepare("SELECT * from reminders WHERE user_id = (?)").all(message.author.id);
+		const userReminders = reminders.getReminders(message.author.id);
 
-		let guild_id = "dm";
-		if (message.channel.type !== "dm") guild_id = message.guild.id;
+		let guildID = "dm";
+		if (message.channel.type !== "dm") guildID = message.guild.id;
 
 		if (args[0] === "clear") {
 			if (args.length === 2) {
-				const deleteResult = db.prepare("DELETE FROM reminders WHERE user_id = (?) AND id = (?)").run(message.author.id, args[1]);
-
-				if (!deleteResult.changes) return message.channel.send(`❣️ **Reminder ${args[1]} could not be cleared.**`);
-
-				clearTimeout(reminderObj[args[1]]);
-				delete reminderObj[args[1]];
-
-				return message.channel.send(`💖 **Reminder ${args[1]} cleared.**`);
+				const result = reminders.killReminder(args[1], message.author.id);
+				if (!result) embed.setDescription(
+					`❣️ **${message.author.username}**, ${args[1]} could not be cleared. ⏰`
+				);
+				embed.setDescription(`💞 **${message.author.username}**, I cleared reminder **${args[1]}**. ⏰`);
+				return message.channel.send({ embed: embed });
 			}
 
-			reminders.forEach(({ id }) => {
-				db.prepare("DELETE FROM reminders WHERE user_id = (?) AND id = (?)").run(message.author.id, id);
-
-				clearTimeout(reminderObj[id]);
-				delete reminderObj[id];
+			userReminders.forEach(({ id }) => {
+				let result = reminders.killReminder(id, message.author.id);
+				if (!result) embed.addField(`**Reminder ${id}**`, `Could not be cleared.`);
 			});
-			return message.channel.send("💖 **Reminders cleared.**");
+			
+			embed.setDescription(`💖 **${message.author.username}**, I cleared all your upcoming reminders. ⏰`);
+			return message.channel.send({ embed: embed });
 		}
 
-		const currentTime = Date.now();
-		const embed = new Discord.MessageEmbed()
-			.setColor("#36393f");
+		console.log(userReminders);
 
-		let validReminders = reminders.filter(reminder => {
-			if (reminder.guild_id === guild_id) return true;
+		let validReminders = userReminders.filter(reminder => {
+			if (reminder.guild_id === guildID) return true;
 			return false;
 		});
+
+		console.log(validReminders);
 
 		if (validReminders.length) {
 			embed.setDescription(`💞 **${message.author.username}**, here are your upcoming reminders: ⏰`);
 			validReminders.forEach(reminder => {
-				const timeToRun = ms(reminder.end_time - currentTime, { long: true });
-				embed.addField(`ID ${reminder.id}, in ${timeToRun}`, reminder.message);
+				const duration = ms(reminder.end_time - Date.now(), { long: true });
+				embed.addField(`Reminder ${reminder.id}, in ${duration}`, reminder.message);
 			});
 		} else {
 			embed.setDescription(`💖 **${message.author.username}**, you don't have any upcoming reminders! ⏰`);

--- a/commands/reminders.js
+++ b/commands/reminders.js
@@ -1,6 +1,6 @@
-const Discord = require("discord.js");
-const ms = require('ms');
 const reminders = require("../utils/reminders.js");
+const embed = require("../utils/embed.js");
+const ms = require('ms');
 
 module.exports = {
 	name: "reminders",
@@ -10,50 +10,60 @@ module.exports = {
 	cooldown: 5,
 	guildOnly: false,
 	execute(message, args) {
-		const embed = new Discord.MessageEmbed()
-			.setColor("#36393f");
-		// select all from reminders
-		// const reminders = db.prepare("SELECT * from reminders WHERE user_id = (?)").all(message.author.id);
 		const userReminders = reminders.getReminders(message.author.id);
 
 		let guildID = "dm";
 		if (message.channel.type !== "dm") guildID = message.guild.id;
 
-		if (args[0] === "clear") {
-			if (args.length === 2) {
-				const result = reminders.killReminder(args[1], message.author.id);
-				if (!result) embed.setDescription(
-					`❣️ **${message.author.username}**, ${args[1]} could not be cleared. ⏰`
-				);
-				embed.setDescription(`💞 **${message.author.username}**, I cleared reminder **${args[1]}**. ⏰`);
-				return message.channel.send({ embed: embed });
-			}
-
-			userReminders.forEach(({ id }) => {
-				let result = reminders.killReminder(id, message.author.id);
-				if (!result) embed.addField(`**Reminder ${id}**`, `Could not be cleared.`);
-			});
-			
-			embed.setDescription(`💖 **${message.author.username}**, I cleared all your upcoming reminders. ⏰`);
-			return message.channel.send({ embed: embed });
-		}
 
 		let validReminders = userReminders.filter(reminder => {
 			if (reminder.guild_id === guildID) return true;
 			return false;
 		});
 
-		if (validReminders.length) {
-			embed.setDescription(`💞 **${message.author.username}**, here are your upcoming reminders: ⏰`);
-			validReminders.forEach(reminder => {
-				const duration = ms(reminder.end_time - Date.now(), { long: true });
-				embed.addField(`Reminder ${reminder.id}, in ${duration}`, reminder.message);
+		if (!validReminders.length) {
+			return message.channel.send({
+				embed: embed(`💖 **${message.author.username}**, you don't have any upcoming reminders! ⏰`)
 			});
-		} else {
-			embed.setDescription(`💖 **${message.author.username}**, you don't have any upcoming reminders! ⏰`);
 		}
 
-		// tell user about their reminders
-		message.channel.send({ embed: embed });
+		if (args[0] === "clear") {
+			if (args.length === 2) {
+				const result = reminders.killReminder(args[1], message.author.id);
+
+				if (!result) {
+					return message.channel.send({
+						embed: embed(`❣️ **${message.author.username}**, ${args[1]} could not be cleared. ⏰`)
+					});
+				}
+
+				return message.channel.send({
+					embed: embed(`💞 **${message.author.username}**, I cleared reminder **${args[1]}**. ⏰`)
+				});
+			}
+
+			const clearEmbed = embed(`💖 **${message.author.username}**, I cleared all your upcoming reminders. ⏰`);
+
+			validReminders.forEach(({ id }) => {
+				let result = reminders.killReminder(id, message.author.id);
+				if (!result) clearEmbed.addField(`**Reminder ${id}**`, `Could not be cleared.`);
+			});
+			
+			return message.channel.send({
+				embed: clearEmbed
+			});
+		}
+
+		if (validReminders.length) {
+			const reminderEmbed = embed(`💞 **${message.author.username}**, here are your upcoming reminders: ⏰`);
+			validReminders.forEach(reminder => {
+				const duration = ms(reminder.end_time - Date.now(), { long: true });
+				reminderEmbed.addField(`Reminder ${reminder.id}, in ${duration}`, reminder.message);
+			});
+			
+			return message.channel.send({
+				embed: reminderEmbed
+			});
+		}
 	}
 };

--- a/commands/roles.js
+++ b/commands/roles.js
@@ -1,4 +1,5 @@
-const { roleBlacklist } = require('../config.json');
+const embed = require("../utils/embed.js");
+const settings = require("../utils/settings.js");
 
 module.exports = {
 	name: 'roles',
@@ -7,15 +8,31 @@ module.exports = {
 	cooldown: 5,
 	guildOnly: true,
 	execute(message) {
+		const guildSettings = settings.getSettings(message.guild.id);
+
+		if (!guildSettings.role_cmds) {
+			return message.channel.send({ embed: embed("❣ **Role commands are disabled.**") });
+		}
+
 		let roles = Array.from(message.guild.roles.cache.values());
-		let assignableRoles = roles
-			.filter(role => !roleBlacklist.includes(role.name))
-			.map(role => role.name).slice(1).sort();
+		let assignableRoles = roles.slice();
 
-		let assignableRoleNames = `\`${assignableRoles.join("`, `")}\``;
+		if (guildSettings.role_blacklist) {
+			assignableRoles = assignableRoles.filter(role => !guildSettings.role_blacklist.includes(role.id));
+		}
 
-		return message.channel.send(
-			`💖 **Here's a list of all the available roles, cutie:**\n${assignableRoleNames}`
-		);
+		assignableRoles = assignableRoles.filter(role => {
+			if (role.name === "@everyone") return false;
+			return true;
+		});
+
+		const rolesEmbed = embed("Roles are mapped with their IDs, so you can blacklist them in settings.")
+			.setTitle(`💖 **Here's a list of all the assignable roles:**`);
+
+		assignableRoles.forEach((role) => {
+			rolesEmbed.addField(role.id, `**${role.name}**`);
+		});
+
+		return message.channel.send({ embed: rolesEmbed });
 	}
 };

--- a/commands/say.js
+++ b/commands/say.js
@@ -1,3 +1,5 @@
+const embed = require("../utils/embed.js");
+
 module.exports = {
 	name: "say",
 	description: "Says anything you want in a channel of your choice!",
@@ -10,23 +12,27 @@ module.exports = {
 		let thingToSay;
 
 		if (!args[0]) {
-			return message.channel.send("❣ **You need to tell me what to say!**");
+			return message.channel.send({
+				embed: embed("❣ **You need to tell me what to say!**")
+			});
 		}
 
 		if (!channelID) {
 			thingToSay = args.join(" ");
-			message.delete().then(() => {
-				message.channel.send(thingToSay);
-			});
+			message.delete().then(() => message.channel.send(thingToSay));
 		} else {
 			thingToSay = args.slice(1).join(" ");
 			let perms = channelID.permissionsFor(message.guild.me).has("SEND_MESSAGES", false);
 
 			if (!perms) {
-				return message.channel.send("💔 **I can't send a message in that channel.**");
+				return message.channel.send({
+					embed: embed("💔 **I can't send a message in that channel.**")
+				});
 			} else {
 				channelID.send(thingToSay).then(() => {
-					message.channel.send("💖 **Message sent.**");
+					message.channel.send({
+						embed: embed("💖 **Message sent.**")
+					});
 				});
 			}
 		}

--- a/commands/settings.js
+++ b/commands/settings.js
@@ -1,0 +1,83 @@
+const settings = require("../utils/settings.js");
+const embed = require("../utils/embed.js");
+
+const rolesFormatter = (roles, message) => roles.map(id => {
+	const role = message.guild.roles.cache.get(id);
+	return `${role.name} (${role.id})`;
+}).join('\n');
+
+const transformations = {
+	"role_cmds": value => new Boolean(value),
+	"welcome_msgs": value => new Boolean(value),
+	"role_blacklist": rolesFormatter,
+	"mod_role": rolesFormatter,
+	"welcome_channel_id": (id, message) => `#${message.guild.channels.cache.get(id).name} (${id})`
+};
+
+const settingsPrettifier = {
+	"prefix": "Prefix",
+	"role_blacklist": "Role Blacklist",
+	"mod_role": "Mod Roles",
+	"role_cmds": "Enable Role Commands",
+	"welcome_msgs": "Enable Welcome Messages",
+	"welcome_channel_id": "Welcome Message Channel"
+};
+
+const transformer = (setting, value, message) => {
+	if (Object.keys(transformations).includes(setting)) return transformations[setting](value, message);
+	if (value == null || undefined) return "not set";
+	return value;
+};
+
+module.exports = {
+	name: "settings",
+	description: "Change the bot settings for your server.",
+	aliases: ["setting", "config"],
+	usage: '<setting> <option>',
+	cooldown: 10,
+	guildOnly: true,
+	modOnly: true,
+	execute(message, args) {
+		let settingsEmbed = embed("❣ Roles and channels are stored by their ID; you must use IDs when modifying these settings.")
+			.setTitle(`⚙️ Settings for ${message.guild.name}`)
+			.setThumbnail(message.guild.iconURL());
+
+		let guildSettings = settings.getSettings(message.guild.id);
+		
+		if (args.length === 0) {
+			let settingArray = Object.entries(guildSettings);
+			settingArray.forEach(([settingName, settingValue]) => {
+				settingsEmbed.addField(`**${settingsPrettifier[settingName]}** (${settingName})`, `\`\`\`js\n${transformer(settingName,settingValue,message)}\`\`\``);
+			});
+			return message.channel.send({ embed: settingsEmbed });
+		}
+
+		if (args.length >= 1) { // setting supplied
+			const setting = args[0];
+			if (!Object.keys(guildSettings).includes(setting)) {
+				return message.channel.send({
+					embed: embed("❣ That setting is not configurable, or doesn't exist.")
+				});
+			}
+
+			if (args.length >= 2) { // value supplied
+				const value = args.slice(1);
+				const result = settings.updateSetting(message.guild.id, setting, value);
+				if (result !== 0) {
+					const errorEmbed = embed("❣ There was an error updating that setting.");
+					errorEmbed.addField("Error:", result);
+					return message.channel.send({ embed: errorEmbed });
+				}
+				
+				guildSettings = settings.getSettings(message.guild.id);
+				return message.channel.send({
+					embed: embed(`💖 **Settings updated:** set ${setting} to \`${transformer(setting, guildSettings[setting])}\``)
+				});
+			}
+
+			return message.channel.send({
+				embed: embed(`💖 **Currently, ${setting} is \`${transformer(setting, guildSettings[setting])}\`.**`)
+			});
+		}
+	}	
+};

--- a/commands/settings.js
+++ b/commands/settings.js
@@ -7,8 +7,8 @@ const rolesFormatter = (roles, message) => roles.map(id => {
 }).join('\n');
 
 const transformations = {
-	"role_cmds": value => new Boolean(value),
-	"welcome_msgs": value => new Boolean(value),
+	"role_cmds": value => Boolean(value),
+	"welcome_msgs": value => Boolean(value),
 	"role_blacklist": rolesFormatter,
 	"mod_role": rolesFormatter,
 	"welcome_channel_id": (id, message) => `#${message.guild.channels.cache.get(id).name} (${id})`

--- a/commands/vote.js
+++ b/commands/vote.js
@@ -1,4 +1,4 @@
-const Discord = require("discord.js");
+const embed = require("../utils/embed.js");
 
 module.exports = {
 	name: "vote",
@@ -8,19 +8,14 @@ module.exports = {
 	guildOnly: true,
 	execute(message, args) {
 		if (!args[0]) {
-			return message.channel.send("❣ **You have to specify a topic!**");
+			return message.channel.send({
+				embed: embed("❣ **You have to specify a topic!**")
+			});
 		}
 
-		const embed = new Discord.MessageEmbed()
-			.setColor("#FF86F1")
-			.setTitle(`${message.author.username} has started a vote! 🗳`)
-			.setDescription(args.join(" "));
-
-		message.delete({
-			timeout: 0,
-			reason: "Vote command setup deleted."
-		});
-		message.channel.send({ embed }).then(msg => {
+		message.channel.send({
+			embed: embed(args.join(" ")).setTitle(`${message.author.username} has started a vote! 🗳`)
+		}).then(msg => {
 			msg.react("👍");
 			msg.react("👎");
 		});

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,5 @@
 {
-	"prefix": "!",
 	"token": "YOUR-TOKEN-HERE",
-	"roleBlacklist": ["Admin", "Cutiebot", "Nitro Booster"],
-	"modRole": "012345678987654321"
+	"dbFolder": "./database",
+	"dbFile": "cutiebot.db"
 }

--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -1,0 +1,11 @@
+const db = require("../utils/database.js");
+const settings = require("../utils/settings.js");
+
+module.exports = (client, guild) => {
+	log.info(`Joined ${guild.name}, owned by ${guild.owner.user.username}.`);
+
+	db.prepare("INSERT INTO settings (guild_id) VALUES (?);").run(guild.id);
+	settings.init(client.guilds.cache.array());
+
+	log.info(`Created settings for ${guild.name}`);
+};

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -1,0 +1,11 @@
+const db = require("../utils/database.js");
+const settings = require("../utils/settings.js");
+
+module.exports = (client, guild) => {
+	log.info(`Left ${guild.name}, owned by ${guild.owner.user.username}.`);
+
+	db.prepare("DELETE FROM settings WHERE guild_id = (?);").run(guild.id);
+	settings.init(client.guilds.cache.array());
+
+	log.info(`Removed settings for ${guild.name}`);
+};

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -1,4 +1,5 @@
 const settings = require("../utils/settings.js");
+const embed = require("../utils/embed.js");
 
 module.exports = (client, member) => {
 	let guildSettings = settings.getSettings(member.guild.id);
@@ -8,7 +9,7 @@ module.exports = (client, member) => {
 
 	const welcomeChannel = member.guild.channels.cache.get(guildSettings.welcome_channel_id);
 
-	welcomeChannel.send(
-		`**${member.user.username} has joined the server. Henlo new fren!** 👋🏻`
-	);
+	welcomeChannel.send({
+		embed: embed(`**${member.user.username} has joined the server. Henlo new fren!** 👋🏻`)
+	});
 };

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -1,6 +1,13 @@
-module.exports = member => {
-	const welcomeChannel = member.guild.channels.cache.find(channel => channel.name === "general");
-	if (!welcomeChannel) return;
+const settings = require("../utils/settings.js");
+
+module.exports = (client, member) => {
+	let guildSettings = settings.getSettings(member.guild.id);
+
+	if (!guildSettings.welcome_msgs) return;
+	if (!guildSettings.welcome_channel_id) return;
+
+	const welcomeChannel = member.guild.channels.cache.get(guildSettings.welcome_channel_id);
+
 	welcomeChannel.send(
 		`**${member.user.username} has joined the server. Henlo new fren!** 👋🏻`
 	);

--- a/events/guildMemberRemove.js
+++ b/events/guildMemberRemove.js
@@ -1,5 +1,14 @@
-module.exports = member => {
-	const welcomeChannel = member.guild.channels.cache.find(channel => channel.name === "general");
-	if (!welcomeChannel) return;
-	welcomeChannel.send(`**${member.user.username} has left the server.** 💔`);
+const settings = require("../utils/settings.js");
+
+module.exports = (client, member) => {
+	let guildSettings = settings.getSettings(member.guild.id);
+
+	if (!guildSettings.welcome_msgs) return;
+	if (!guildSettings.welcome_channel_id) return;
+
+	const welcomeChannel = member.guild.channels.cache.get(guildSettings.welcome_channel_id);
+
+	welcomeChannel.send(
+		`**${member.user.username} has left the server.** 💔`
+	);
 };

--- a/events/guildMemberRemove.js
+++ b/events/guildMemberRemove.js
@@ -1,4 +1,5 @@
 const settings = require("../utils/settings.js");
+const embed = require("../utils/embed.js");
 
 module.exports = (client, member) => {
 	let guildSettings = settings.getSettings(member.guild.id);
@@ -8,7 +9,7 @@ module.exports = (client, member) => {
 
 	const welcomeChannel = member.guild.channels.cache.get(guildSettings.welcome_channel_id);
 
-	welcomeChannel.send(
-		`**${member.user.username} has left the server.** 💔`
-	);
+	welcomeChannel.send({
+		embed: embed(`**${member.user.username} has left the server.** 💔`)
+	});
 };

--- a/events/ready.js
+++ b/events/ready.js
@@ -1,45 +1,40 @@
-const Discord = require("discord.js");
-const db = require("better-sqlite3")("./database/cutiebot.db");
+const settings = require("../utils/settings.js");
+const reminders = require("../utils/reminders.js");
+const allReminders = reminders.getReminders();
 
 module.exports = client => {
-	// check for db file
-	const tableResult = db.prepare("SELECT count(*) from sqlite_master WHERE type='table' AND name = 'reminders';").get();
-	if (!tableResult['count(*)']) {
-		db.prepare(
-			"CREATE TABLE IF NOT EXISTS reminders (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL, channel_id TEXT NOT NULL, guild_id TEXT NOT NULL, message TEXT NOT NULL, start_time INTEGER NOT NULL, end_time INTEGER NOT NULL);"
-		).run();
-		// prep db
-		db.pragma("journal_mode = WAL");
-	}
-
 	log.time("completed");
-	log.info(`Started at ${new Date().toUTCString()}`);
+	log.info(`Logged in as ${client.user.tag} at ${new Date().toLocaleString("en-GB", {
+		weekday: "long",
+		month: "long",
+		year: "numeric",
+		day: "numeric"
+	})}`);
 	log.timeBetween("startup", "completed");
 
+	// should return a promise so we can check state, and how many settings we loaded
+	// and we should also check how many settings we had to create entries for
+	settings.init(client.guilds.cache.array());
+	log.info(`Loaded settings for x guilds.`);
+
+	client.user.setActivity(`${client.guilds.cache.size} server${client.guilds.cache.size !== 1 ? "s" : ""}.`, { type: "WATCHING" })
+		.then(activity => log.info(`Set activity to ${activity.activities[0].type} ${activity.activities[0].name}`))
+		.catch(log.error);
+
 	// set up pending reminders
-	global.reminderObj = {};
-	const reminders = db.prepare("SELECT * from reminders").all();
-	const currentTime = Date.now();
-	reminders.forEach(async (reminder) => {
+	allReminders.forEach(async (reminder) => {
 		const userToRemind = await client.users.fetch(reminder.user_id);
 		const channelToPost = await client.channels.fetch(reminder.channel_id);
-		const timeToRun = reminder.end_time - currentTime;
-		const removeReminder = db.prepare("DELETE FROM reminders WHERE id = (?)");
-		const reminderEmbed = new Discord.MessageEmbed()
-			.setColor("#36393f")
-			.setDescription(`⏰ ${reminder.message}`);
-
-		const onCompletion = () => {
-			channelToPost.send(`💖 **${userToRemind.toString()}**, here's your reminder:`, { embed: reminderEmbed });
-			removeReminder.run(reminder.id);
-		};
-
-		if (timeToRun <= 0) {
-			onCompletion();
-		} else {
-			let timeoutID = setTimeout(onCompletion, timeToRun);
-			reminderObj[reminder.id] = timeoutID;
-			log.info(`Set up ${reminders.length} reminder from database.`);
-		}
+		const duration = reminder.end_time - Date.now();
+		reminders.registerReminder(
+			userToRemind,
+			channelToPost,
+			undefined,
+			reminder.message,
+			duration,
+			reminder.id
+		);
 	});
+
+	log.info(`Set up ${allReminders.length} reminder${allReminders.size !== 1 ? "s": ""} from database.`); 
 };

--- a/events/ready.js
+++ b/events/ready.js
@@ -12,14 +12,15 @@ module.exports = client => {
 	})}`);
 	log.timeBetween("startup", "completed");
 
-	// should return a promise so we can check state, and how many settings we loaded
-	// and we should also check how many settings we had to create entries for
-	settings.init(client.guilds.cache.array());
-	log.info(`Loaded settings for x guilds.`);
+	const guildSettings = settings.init(client.guilds.cache.array());
 
-	client.user.setActivity(`${client.guilds.cache.size} server${client.guilds.cache.size !== 1 ? "s" : ""}.`, { type: "WATCHING" })
-		.then(activity => log.info(`Set activity to ${activity.activities[0].type} ${activity.activities[0].name}`))
-		.catch(log.error);
+	if (guildSettings.cached > 0) {
+		log.info(`Loaded settings for ${guildSettings.cached} server${guildSettings.cached != 1 ? "s": ""}.`);
+	}
+
+	if (guildSettings.created > 0) {
+		log.info(`Created settings for ${guildSettings.created} server${guildSettings.created != 1 ? "s": ""}.`);
+	}
 
 	// set up pending reminders
 	allReminders.forEach(async (reminder) => {
@@ -36,5 +37,12 @@ module.exports = client => {
 		);
 	});
 
-	log.info(`Set up ${allReminders.length} reminder${allReminders.size !== 1 ? "s": ""} from database.`); 
+	if (allReminders.length) {
+		log.info(`Set up ${allReminders.length} reminder${allReminders.size !== 1 ? "s": ""} from database.`);
+	}
+	
+	client.user.setActivity(`${client.guilds.cache.size} server${client.guilds.cache.size !== 1 ? "s" : ""}.`, { type: "WATCHING" })
+		.then(activity => log.info(`Set activity to ${activity.activities[0].type} ${activity.activities[0].name}`))
+		.catch(log.error);
+
 };

--- a/index.js
+++ b/index.js
@@ -3,11 +3,16 @@ loggerInit();
 log.time("startup");
 log.info("Starting Cutiebot!");
 
+// cache settings;
+// const settings = require("./utils/settings.js");
+
+// import discord.js, token, and set up client
 const Discord = require("discord.js");
-const client = new Discord.Client();
-const chalk = require("chalk");
-const fs = require("fs");
 const { token } = require("./config.json");
+const client = new Discord.Client();
+
+const fs = require("fs");
+const chalk = require("chalk");
 
 // setup command handler
 client.commands = new Discord.Collection();
@@ -35,6 +40,7 @@ for (const file of eventFiles) {
 	log.debug(`Loaded ${chalk.bold(eventName)} event.`);
 }
 
+// error handling
 process.on("unhandledRejection", error =>
 	log.error(`Uncaught Promise Rejection: ${error}`)
 );

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ loggerInit();
 log.time("startup");
 log.info("Starting Cutiebot!");
 
-// import discord.js, token, and set up client
 const Discord = require("discord.js");
 const { token } = require("./config.json");
 const client = new Discord.Client();
@@ -11,7 +10,6 @@ const client = new Discord.Client();
 const fs = require("fs");
 const chalk = require("chalk");
 
-// setup command handler
 client.commands = new Discord.Collection();
 const commandFiles = fs
 	.readdirSync("./commands")
@@ -24,7 +22,6 @@ for (const file of commandFiles) {
 	log.debug(`Loaded ${chalk.bold(command.name)} command.`);
 }
 
-// setup event handler
 const eventFiles = fs
 	.readdirSync("./events/")
 	.filter(file => file.endsWith(".js"));
@@ -37,7 +34,6 @@ for (const file of eventFiles) {
 	log.debug(`Loaded ${chalk.bold(eventName)} event.`);
 }
 
-// error handling
 process.on("unhandledRejection", error => {
 	log.error(`Uncaught Promise Rejection`);
 	console.error(error);

--- a/index.js
+++ b/index.js
@@ -3,9 +3,6 @@ loggerInit();
 log.time("startup");
 log.info("Starting Cutiebot!");
 
-// cache settings;
-// const settings = require("./utils/settings.js");
-
 // import discord.js, token, and set up client
 const Discord = require("discord.js");
 const { token } = require("./config.json");
@@ -41,9 +38,10 @@ for (const file of eventFiles) {
 }
 
 // error handling
-process.on("unhandledRejection", error =>
-	log.error(`Uncaught Promise Rejection: ${error}`)
-);
+process.on("unhandledRejection", error => {
+	log.error(`Uncaught Promise Rejection`);
+	console.error(error);
+});
 
 client
 	.on("disconnect", () => log.warn("Bot is disconnecting..."))

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "run": [
       "lint"
     ]
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/utils/database.js
+++ b/utils/database.js
@@ -13,9 +13,8 @@ let db;
 try {
 	db = new Database(dbFullPath, { fileMustExist: true });
 } catch (error) {
-	log.warn("Database file does not exist");
-	log.info("Attempting to create database file");
-
+	log.warn("Database file does not exist!");
+	log.info("Attempting to create database file...");
 	db = new Database(dbFullPath);
 	db.pragma("journal_mode = WAL"); //set journaling mode
 }
@@ -37,6 +36,7 @@ db.prepare(
         guild_id TEXT NOT NULL,
         prefix TEXT NOT NULL DEFAULT '!',
         mod_role TEXT,
+        role_cmds INTEGER NOT NULL DEFAULT 0,
         role_blacklist TEXT,
         welcome_msgs INTEGER NOT NULL DEFAULT 0,
         welcome_channel_id TEXT);`

--- a/utils/database.js
+++ b/utils/database.js
@@ -1,0 +1,45 @@
+const Database = require("better-sqlite3");
+
+const fs = require("fs");
+
+const { dbFolder, dbFile } = require("../config.json");
+const dbFullPath = `${dbFolder}/${dbFile}`;
+if (!fs.existsSync(dbFolder)) {
+	fs.mkdirSync(dbFolder);
+}
+
+// attempt to open db file 
+let db;
+try {
+	db = new Database(dbFullPath, { fileMustExist: true });
+} catch (error) {
+	log.warn("Database file does not exist");
+	log.info("Attempting to create database file");
+
+	db = new Database(dbFullPath);
+	db.pragma("journal_mode = WAL"); //set journaling mode
+}
+
+db.prepare(
+	`CREATE TABLE IF NOT EXISTS reminders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id TEXT NOT NULL, 
+        channel_id TEXT NOT NULL, 
+        guild_id TEXT NOT NULL, 
+        message TEXT NOT NULL, 
+        start_time INTEGER NOT NULL, 
+        end_time INTEGER NOT NULL);`
+).run();
+
+db.prepare(
+	`CREATE TABLE IF NOT EXISTS settings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        guild_id TEXT NOT NULL,
+        prefix TEXT NOT NULL DEFAULT '!',
+        mod_role TEXT,
+        role_blacklist TEXT,
+        welcome_msgs INTEGER NOT NULL DEFAULT 0,
+        welcome_channel_id TEXT);`
+).run();
+
+module.exports = db;

--- a/utils/embed.js
+++ b/utils/embed.js
@@ -1,0 +1,6 @@
+const Discord = require("discord.js");
+
+module.exports = text => {
+	let embed = new Discord.MessageEmbed().setColor("#36393f").setDescription(text);
+	return embed;
+};

--- a/utils/reminders.js
+++ b/utils/reminders.js
@@ -1,5 +1,6 @@
-const Discord = require("discord.js");
 const db = require("../utils/database.js");
+const embed = require("../utils/embed.js");
+
 const reminderObject = {};
 
 const createReminder = db.prepare(`
@@ -9,18 +10,15 @@ const createReminder = db.prepare(`
     guild_id,
     message,
     start_time,
-    end_time) VALUES (?, ?, ?, ?, ?, ?)`
+		end_time
+	) VALUES (?, ?, ?, ?, ?, ?)`
 );
 
 const removeReminder = db.prepare("DELETE FROM reminders WHERE id = (?)");
 const removeUserReminder = db.prepare("DELETE FROM reminders WHERE id = (?) AND user_id = (?)");
 
-const reminderEmbed = (reminderContent) => new Discord.MessageEmbed()
-	.setColor("#36393f")
-	.setDescription(`⏰ ${reminderContent}`);
-
-const messageFunction = (channel, user, content) => channel.send(`💖 **${user.toString()}**, here's your reminder:`, {
-	embed: reminderEmbed(content)
+const messageFunction = (channel, user, content) => channel.send(`💖 **${user.toString()}, here's your reminder:**`, {
+	embed: embed(`⏰ ${content}`)
 });
     
 module.exports = {

--- a/utils/reminders.js
+++ b/utils/reminders.js
@@ -54,6 +54,6 @@ module.exports = {
 		const deleteResult = removeUserReminder.run(id, userID);
 		clearTimeout(reminderObject[id]);
 		delete reminderObject[id];
-		return new Boolean (deleteResult.changes);
+		return Boolean (deleteResult.changes);
 	}
 };

--- a/utils/reminders.js
+++ b/utils/reminders.js
@@ -1,0 +1,61 @@
+const Discord = require("discord.js");
+const db = require("../utils/database.js");
+const reminderObject = {};
+
+const createReminder = db.prepare(`
+  INSERT INTO reminders (
+    user_id,
+    channel_id,
+    guild_id,
+    message,
+    start_time,
+    end_time) VALUES (?, ?, ?, ?, ?, ?)`
+);
+
+const removeReminder = db.prepare("DELETE FROM reminders WHERE id = (?)");
+const removeUserReminder = db.prepare("DELETE FROM reminders WHERE id = (?) AND user_id = (?)");
+
+const reminderEmbed = (reminderContent) => new Discord.MessageEmbed()
+	.setColor("#36393f")
+	.setDescription(`⏰ ${reminderContent}`);
+
+const messageFunction = (channel, user, content) => channel.send(`💖 **${user.toString()}**, here's your reminder:`, {
+	embed: reminderEmbed(content)
+});
+    
+module.exports = {
+	getReminders: userID => {
+		if (!userID) return db.prepare("SELECT * from reminders").all();
+		return db.prepare("SELECT * from reminders WHERE user_id = (?)").all(userID);
+	},
+	registerReminder: (user, channel, guild, content, duration, id) => {
+		if (duration <= 0) {
+			if (id !== undefined) removeReminder.run(id);
+			return messageFunction(channel, user, content);
+		}
+    
+		let reminderID = id;
+		if (reminderID === undefined) {
+			// if no id is supplied add to database in turn generating one
+			let guildID = "dm";
+			if (channel.type !== "dm") guildID = guild.id;
+			const startTime = Date.now();
+			const endTime = startTime + duration;
+			reminderID = createReminder.run(user.id, channel.id, guildID, content, startTime, endTime).lastInsertRowid;
+		}
+    
+		const timeoutID = setTimeout(() => {
+			messageFunction(channel, user, content);
+			removeReminder.run(reminderID);
+		}, duration);
+    
+		reminderObject[reminderID] = timeoutID;
+	},
+  
+	killReminder: (id, userID) => {
+		const deleteResult = removeUserReminder.run(id, userID);
+		clearTimeout(reminderObject[id]);
+		delete reminderObject[id];
+		return new Boolean (deleteResult.changes);
+	}
+};

--- a/utils/settings.js
+++ b/utils/settings.js
@@ -1,0 +1,160 @@
+const db = require("./database.js");
+const settings = {};
+
+const keyWords = {
+	add: ["add", "push"],
+	remove: ["remove", "delete"],
+	true: ["1","on","true"],
+	false: ["0","off","false"]
+};
+
+
+const boolParser = input => {
+	if (keyWords.true.includes(input)) return 1;
+	if (keyWords.false.includes(input)) return 0;
+	throw `Invalid argument \`${input}\`, argument should be of type: \`bool\`.`;
+};
+
+const modifyArray = (flag, array, item) => {
+	let itemArray = [item];
+	if (Array.isArray(item)) itemArray = item.slice();
+	let adding;
+	itemArray.forEach(item => {
+		let itemExists = array.includes(item);
+		if (keyWords.add.includes(flag)) {
+			adding = true;
+			if (itemExists) throw `\`${item}\` already listed.`;
+		} else if (keyWords.remove.includes(flag)){
+			if (!itemExists) throw `\`${item}\` not listed.`;
+			adding = false;
+		} else {
+			throw `Unknown key word: \`${flag}\`.`; 
+		}
+	});
+
+	if (adding) {
+		array.push(...itemArray);
+	} else {
+		itemArray.forEach(item => {
+			let index = array.indexOf(item);
+			array.splice(index, 1);
+		});
+	}
+};
+
+const roleListHandler = (id, input, key) => {
+	const roles = (settings[id][key] || []).slice();
+	if (input.length === 1) {
+		modifyArray("add", roles, input[0]);
+		return roles;
+	}
+	modifyArray(input[0], roles, input.slice(1));
+	return roles;
+};
+
+// settings validators
+const validSettings = {
+	"prefix": (id, [input]) => {
+		if (typeof(input) !== "string") throw `Type error; prefix should be a \`string\`.`;
+		if (input.length !== 1) throw `Prefix too long; should be of length \`1\``;
+		return input;
+	},
+	"role_blacklist": (id, input) => roleListHandler(id, input, "role_blacklist"),
+	"mod_role": (id, input) => roleListHandler(id, input, "mod_role"),
+	"role_cmds": (id, [input]) => boolParser(input),
+	"welcome_msgs": (id, [input]) => boolParser(input),
+	"welcome_channel_id": (id, [input]) => input,
+};
+
+// settings helpers
+const generateParameterString = len => {
+	const questionMarkArray = new Array(len).fill("?");
+	return `(${questionMarkArray})`;
+
+};
+
+const initFunction = currentGuilds => {
+	// fetch Guilds in db
+	const expectedGuilds = db.prepare('SELECT guild_id FROM settings').all();
+	const expectedGuildIDs = expectedGuilds.map(guildOptions => guildOptions.guild_id);
+
+	// fetch Guilds bot is on
+	const currentGuildIDs = currentGuilds.map(guild => guild.id);
+	const numberOfGuilds = Math.max(expectedGuilds.length, currentGuilds.length);
+	let newGuilds = 0;
+
+	for (let i = 0; i < numberOfGuilds; i++) {
+		const currentGuild = currentGuilds[i];
+		if (currentGuilds.length > i) {
+			if (!expectedGuildIDs.includes(currentGuild.id)) {
+				log.warn(`${currentGuild.name} missing from database, adding...`);
+				// add guild to database here
+				newGuilds = db.prepare("INSERT INTO settings (guild_id) VALUES (?);").run(currentGuild.id);
+			}
+		}
+
+		const expectedGuild = expectedGuilds[i];
+		if (expectedGuilds.length > i) {
+			if (!currentGuildIDs.includes(expectedGuild.guild_id)) {
+				log.warn(`Extraneous guild in database with ID: ${expectedGuild.guild_id} will be removed`);
+				// remove guild from database here
+				db.prepare("DELETE FROM settings WHERE guild_id = ?;").run(expectedGuild.guild_id);
+			}
+		}
+	}
+
+	const guildOptions = db.prepare(
+		`SELECT ${Object.keys(validSettings).join(",")} FROM settings WHERE guild_id IN ${generateParameterString(currentGuildIDs.length)}`
+	).all(...currentGuildIDs);
+
+	currentGuilds.forEach((guild,i) => {
+		let guildOptionsParsed = {};
+		Object.entries(guildOptions[i]).forEach(([key, value]) => {
+			guildOptionsParsed[key] = value;
+
+			if (key === "mod_role" || key === "role_blacklist") guildOptionsParsed[key] = JSON.parse(value);
+		});
+
+		settings[guild.id] = guildOptionsParsed;
+	});
+
+	let result = {
+		cached: expectedGuilds.length,
+		created: `${newGuilds.length !== undefined ? newGuilds.length : 0}`
+	};
+
+	return result;
+};
+
+const updateSetting = (id, setting, valueArray) => {
+	// check if supplied setting is allowed
+	if (!Object.keys(validSettings).includes(setting)) throw `Setting \`${setting}\` was not found.`;
+
+	let transformedInput;
+	try {
+		transformedInput = validSettings[setting](id, valueArray);
+		settings[id][setting] = transformedInput;
+		if (Array.isArray(transformedInput)) transformedInput = JSON.stringify(transformedInput);
+		db.prepare(`UPDATE settings SET ${setting} = ? WHERE guild_id = ?`).run(transformedInput, id);
+		return 0;
+	} catch (error) {
+		return error;
+	}
+};
+
+module.exports = {
+	init: currentGuilds => initFunction(currentGuilds),
+	getSettings: id => settings[id],
+	updateSetting: (id, setting, valueArray) => updateSetting(id, setting, valueArray)
+};
+
+// QOL Improvements:
+// keyword of delete instead of anything like poo :tick:
+// let user know when issue is thrown :tick:
+// pick welcome channel in guildMemberAdd/Remove from settings :tick:
+// print id's with roles :tick:
+// use embeds everywhere :tick: 
+// print role objects with id's in settings printout :tick:
+// print welcome channel name in settings printout :tick:
+
+// aliases for setting names (maybe, if it isnt hard)


### PR DESCRIPTION
This PR refactors Cutiebot's configuration. Now taking advantage of the database, we store settings per-guild instead of in `config.json`, which now only holds the bot token. All commands have been given a pass over and everything uses embeds, which greatly separates the bot's messages from users.

