### PR TITLE
Update command filters

### DIFF
--- a/commands/eval.js
+++ b/commands/eval.js
@@ -6,6 +6,7 @@ module.exports = {
 	cooldown: 0,
 	guildOnly: true,
 	modOnly: true,
+	hidden: true,
 	execute(message, args) {
 		// return silently if not Sierra#0001
 		// due to the nature of eval

--- a/commands/reboot.js
+++ b/commands/reboot.js
@@ -6,6 +6,7 @@ module.exports = {
 	cooldown: 0,
 	guildOnly: false,
 	modOnly: true,
+	hidden: true,
 	execute(message) {
 		// return silently if not Sierra#0001
 		if (message.author.id !== "190917462265430016") return;

--- a/commands/reminders.js
+++ b/commands/reminders.js
@@ -5,7 +5,6 @@ const ms = require('ms');
 module.exports = {
 	name: "reminders",
 	description: "Shows all reminders. Optionally, clears reminders.",
-	aliases: [],
 	usage: '<clear> [id]',
 	cooldown: 5,
 	guildOnly: false,

--- a/commands/roles.js
+++ b/commands/roles.js
@@ -22,16 +22,32 @@ module.exports = {
 		}
 
 		assignableRoles = assignableRoles.filter(role => {
+			if (role.name === "@everyone" || role.name === "Cutiebot") return false;
+			return true;
+		});
+
+		const rolesEmbed = embed("You can assign or remove these roles with the `!role` command.")
+			.setTitle(`💖 **Here's a list of all the assignable roles:**`);
+
+		let roleList = [];
+		assignableRoles.forEach((role) => {
+			roleList.push(`**${role.name}** \u2013 ${role.id}`);
+		});
+
+		rolesEmbed.addField(`Roles in ${message.guild.name}:`, roleList.join(`\n`));
+
+		let userRoles = Array.from(message.member.roles.cache.values());
+		let cleanedUserRoles = userRoles.filter(role => {
 			if (role.name === "@everyone") return false;
 			return true;
 		});
 
-		const rolesEmbed = embed("Roles are mapped with their IDs, so you can blacklist them in settings.")
-			.setTitle(`💖 **Here's a list of all the assignable roles:**`);
-
-		assignableRoles.forEach((role) => {
-			rolesEmbed.addField(role.id, `**${role.name}**`);
-		});
+		if (cleanedUserRoles.length) {
+			rolesEmbed.addField(`Your roles:`, `${cleanedUserRoles.join(", ")}`);
+		} else {
+			rolesEmbed.addField(`Your roles:`, "You don't have any assigned roles.");
+		}
+		
 
 		return message.channel.send({ embed: rolesEmbed });
 	}


### PR DESCRIPTION
- Add hidden property to commands that should not be shown in `help`
- Update filter for help command to show mod-only commands to moderators
- Update roles command to use the same filtering
- Update roles command to show user their current roles

In the previous version, the help and roles commands would become unwieldy due to the limits of a message embed. In production, on a guild with over 25 user assignable roles, not all roles would be displayed on the embed (and it was utterly giant). I have refactored the way that commands and roles are displayed in these embeds.