### PR TITLE
Update roles command to filter out managed roles

### DIFF
--- a/commands/roles.js
+++ b/commands/roles.js
@@ -22,7 +22,8 @@ module.exports = {
 		}
 
 		assignableRoles = assignableRoles.filter(role => {
-			if (role.name === "@everyone" || role.name === "Cutiebot") return false;
+			if (role.name === "@everyone") return false;
+			if (role.managed) return false;
 			return true;
 		});
 


### PR DESCRIPTION
Changes the filtering method to use the `managed` property in a role object. This way, bot roles and the Nitro Booster role will all be filtered out automatically.