### PR TITLE
Update guild events to set the activity correctly

### DIFF
--- a/commands/eval.js
+++ b/commands/eval.js
@@ -27,7 +27,7 @@ module.exports = {
 			const code = args.join(" ");
 			let evaled = eval(code);
 			if (typeof evaled !== "string") evaled = require("util").inspect(evaled);
-			data.push(clean(evaled), { code: "js" });
+			data.push(clean(evaled));
 
 			log.debug(data);
 			message.channel.send(data, {

--- a/events/guildCreate.js
+++ b/events/guildCreate.js
@@ -8,4 +8,8 @@ module.exports = (client, guild) => {
 	settings.init(client.guilds.cache.array());
 
 	log.info(`Created settings for ${guild.name}`);
+
+	client.user.setActivity(`${client.guilds.cache.size} server${client.guilds.cache.size !== 1 ? "s" : ""}.`, { type: "WATCHING" })
+		.then(activity => log.info(`Set activity to ${activity.activities[0].type} ${activity.activities[0].name}`))
+		.catch(log.error);
 };

--- a/events/guildDelete.js
+++ b/events/guildDelete.js
@@ -8,4 +8,8 @@ module.exports = (client, guild) => {
 	settings.init(client.guilds.cache.array());
 
 	log.info(`Removed settings for ${guild.name}`);
+
+	client.user.setActivity(`${client.guilds.cache.size} server${client.guilds.cache.size !== 1 ? "s" : ""}.`, { type: "WATCHING" })
+		.then(activity => log.info(`Set activity to ${activity.activities[0].type} ${activity.activities[0].name}`))
+		.catch(log.error);
 };


### PR DESCRIPTION
Now setting the client activity each time we leave or join a guild, this means the number of guilds is now accurate.

Also removed an unnecessary object in `eval` that was causing unintended output.