### PR TITLE
Add GHA to build images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 node_modules/
 database/
+.*
+*.md

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/cutie-club/cutiebot:latest
+          platforms: linux/amd64, linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:lts-alpine
+FROM node:16-alpine3.15
 LABEL org.opencontainers.image.source https://github.com/cutie-club/cutiebot
 
-RUN apk add --no-cache yarn python3 build-base
+RUN apk add --no-cache yarn
 
 WORKDIR /usr/cutiebot
 COPY . /usr/cutiebot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM node:16.14-alpine
-COPY . /usr/cutiebot
+FROM node:lts-alpine
+LABEL org.opencontainers.image.source https://github.com/cutie-club/cutiebot
 
-RUN apk update
-RUN apk upgrade --available
-RUN apk add yarn
+RUN apk add --no-cache yarn python3 build-base
 
 WORKDIR /usr/cutiebot
-RUN yarn
+COPY . /usr/cutiebot
+RUN yarn --prod
 
 CMD [ "yarn", "run", "start" ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Cutie Club Discord Server bot, written using [Discord.js](https://discord.js
 
 ## Inviting to a Server
 
-To add the bot to a server, click the following link; <https://discordapp.com/api/oauth2/authorize?client_id=633716546568585216&permissions=268561478&scope=bot>
+To add the bot to a server, click the following link; <https://discord.com/api/oauth2/authorize?client_id=633716546568585216&permissions=1376805841990&scope=bot%20applications.commands>
 
 Cutiebot requires the following permissions;
 
@@ -14,10 +14,14 @@ Cutiebot requires the following permissions;
 + Ban Members
 + View Channels
 + Send Messages
++ Send Messages in Threads
 + Manage Messages
 + Embed Links
 + Attach Files
 + Read Message History
++ Read Messages / View Channels
++ Add Reactions
++ Use External Emojis
 + Add Reactions
 ```
 
@@ -42,9 +46,15 @@ Once finished, run `cd cutiebot`, followed by `yarn install`. You may need to sw
 
 You can start the bot using `npm run dev:start`, which starts the bot using Nodemon.
 
-## Docker Setup
+## Docker
 
 To run the bot via Docker, install Docker on your machine.
+
+To pull the pre-published Docker image:
+
+```sh
+docker pull ghcr.io/cutie-club/cutiebot:latest
+```
 
 Run the following to build the image:
 
@@ -61,5 +71,3 @@ docker run -d \
   --mount type=bind,source="$(pwd)/database",target=/usr/cutiebot/database \
   cutiebot:latest
 ```
-
-Alternatively, you can supply a `.env` file in the project's root directory with DISCORD_TOKEN set.


### PR DESCRIPTION
Fixes #27

This adds a GitHub Actions workflow to build images for `linux/arm64` and `linux/amd64`.