### PR TITLE
Minify Docker Images

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,6 +36,6 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/cutie-club/cutiebot:latest
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:16-alpine3.15 as build
 WORKDIR /usr/cutiebot
 COPY . /usr/cutiebot
-RUN yarn install --prod
+RUN apk add --no-cache python3 build-base && yarn install --prod
 
 FROM alpine:3.15
 LABEL org.opencontainers.image.source https://github.com/cutie-club/cutiebot

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apk add --no-cache nodejs
 WORKDIR /usr/cutiebot
 COPY --from=build  /usr/cutiebot /usr/cutiebot
 
-CMD [ "node", "deploy-commands.js", "&&", "node", "index.js" ]
+CMD node deploy-commands.js && node index.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM node:16-alpine3.15
-LABEL org.opencontainers.image.source https://github.com/cutie-club/cutiebot
-
-RUN apk add --no-cache yarn
-
+FROM node:16-alpine3.15 as build
 WORKDIR /usr/cutiebot
 COPY . /usr/cutiebot
-RUN yarn --prod
+RUN yarn install --prod
 
-CMD [ "yarn", "run", "start" ]
+FROM alpine:3.15
+LABEL org.opencontainers.image.source https://github.com/cutie-club/cutiebot
+ENV NODE_ENV production
+
+RUN apk add --no-cache nodejs
+
+WORKDIR /usr/cutiebot
+COPY --from=build  /usr/cutiebot /usr/cutiebot
+
+CMD [ "node", "deploy-commands.js", "&&", "node", "index.js" ]


### PR DESCRIPTION
This PR reduces the size of images we are creating. I am also adding linux/arm/v7 as a target so I can run this on SBCs.

- Add multi-stage Dockerfile (credit: @mini-ninja-64 )
- Add linux/arm/v7 to buildx platforms

We are now down to 73.5MB, from 234MB. That's an approximate 69% <sup>(nice)</sup> saving.

```sh
$ docker images
REPOSITORY                    TAG               IMAGE ID       CREATED          SIZE
cutiebot                      latest            7b52d8b53397   14 seconds ago   73.5MB
ghcr.io/cutie-club/cutiebot   latest            2acb35507fa3   4 days ago        234MB
```